### PR TITLE
Fix header typo

### DIFF
--- a/yas-viz.html
+++ b/yas-viz.html
@@ -13,7 +13,7 @@
   </head>
   <body>
 	<section id="content">
-	  <h1>y86 Assembly Visaulizer</h1>
+	  <h1>y86 Assembly Visualizer</h1>
 	  <section id="preAssemble">
 		<div id="editor"></div>
 		<button id="assemble">Assemble</button>


### PR DESCRIPTION
Just fixed the typo in the h1 of the content section.
